### PR TITLE
Update menu PDFs and navigation improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,11 +41,10 @@
     <link rel="dns-prefetch" href="https://www.google-analytics.com" />
 
     <!-- Favicon and app icons -->
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#dc2626" />
+    <link rel="icon" type="image/webp" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=webp&width=32" sizes="32x32" />
+    <link rel="icon" type="image/webp" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=webp&width=16" sizes="16x16" />
+    <link rel="apple-touch-icon" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=webp&width=180" sizes="180x180" />
+    <link rel="mask-icon" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=svg" color="#dc2626" />
     <link rel="manifest" href="/site.webmanifest" />
 
     <!-- Open Graph default meta tags - will be enhanced by SEOHead component -->

--- a/index.html
+++ b/index.html
@@ -41,10 +41,10 @@
     <link rel="dns-prefetch" href="https://www.google-analytics.com" />
 
     <!-- Favicon and app icons -->
-    <link rel="icon" type="image/webp" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=webp&width=32" sizes="32x32" />
-    <link rel="icon" type="image/webp" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=webp&width=16" sizes="16x16" />
-    <link rel="apple-touch-icon" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=webp&width=180" sizes="180x180" />
-    <link rel="mask-icon" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5e39b810c2894e67b28c0c7d40e97293?format=svg" color="#dc2626" />
+    <link rel="icon" type="image/webp" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5f4c6502032142a780768539c7c84a2d?format=webp&width=32" sizes="32x32" />
+    <link rel="icon" type="image/webp" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5f4c6502032142a780768539c7c84a2d?format=webp&width=16" sizes="16x16" />
+    <link rel="apple-touch-icon" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5f4c6502032142a780768539c7c84a2d?format=webp&width=180" sizes="180x180" />
+    <link rel="mask-icon" href="https://cdn.builder.io/api/v1/image/assets%2Fad5fa173f30f42cb936245efbd928c96%2F5f4c6502032142a780768539c7c84a2d?format=svg" color="#dc2626" />
     <link rel="manifest" href="/site.webmanifest" />
 
     <!-- Open Graph default meta tags - will be enhanced by SEOHead component -->

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,11 +7,11 @@ import {
   Mail,
   Clock,
   Instagram,
-  Twitter,
   Apple,
   Smartphone,
   ArrowRight,
   Truck,
+  Music,
 } from "lucide-react";
 
 const Footer = () => {
@@ -37,7 +37,6 @@ const Footer = () => {
   const quickLinks = [
     { name: "About Us", href: "/about" },
     { name: "Menu", href: "/menu" },
-    { name: "Locations", href: "/contact" },
     { name: "Catering", href: "/catering" },
     { name: "Contact", href: "/contact" },
   ];
@@ -48,7 +47,7 @@ const Footer = () => {
       icon: Instagram,
       href: "https://www.instagram.com/hummusbarandgrill/?hl=en",
     },
-    { name: "Twitter", icon: Twitter, href: "https://x.com/hummusbargrill" },
+    { name: "TikTok", icon: Music, href: "https://www.tiktok.com/@hummusbargrill?lang=en" },
   ];
 
   return (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -233,7 +233,10 @@ const Navigation = () => {
                           <button
                             onClick={() => {
                               setIsMenuDropdownOpen(false);
-                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F9f1912d9192648c2a8c51dbe5a32c1b4?alt=media&token=08d85958-fe7c-4dec-bd8f-755bdf616fd7&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                              window.open(
+                                "https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F9f1912d9192648c2a8c51dbe5a32c1b4?alt=media&token=08d85958-fe7c-4dec-bd8f-755bdf616fd7&apiKey=ad5fa173f30f42cb936245efbd928c96",
+                                "_blank",
+                              );
                             }}
                             className="block w-full text-left px-4 py-3 text-sm text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors"
                           >
@@ -433,7 +436,10 @@ const Navigation = () => {
                             onClick={() => {
                               setIsOpen(false);
                               setIsMenuDropdownOpen(false);
-                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F9f1912d9192648c2a8c51dbe5a32c1b4?alt=media&token=08d85958-fe7c-4dec-bd8f-755bdf616fd7&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                              window.open(
+                                "https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F9f1912d9192648c2a8c51dbe5a32c1b4?alt=media&token=08d85958-fe7c-4dec-bd8f-755bdf616fd7&apiKey=ad5fa173f30f42cb936245efbd928c96",
+                                "_blank",
+                              );
                             }}
                             className="block w-full text-left px-4 py-2 text-sm text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
                           >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -233,7 +233,7 @@ const Navigation = () => {
                           <button
                             onClick={() => {
                               setIsMenuDropdownOpen(false);
-                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F62e80d2c7f5843b9a20f8432a4164c35?alt=media&token=8d83d462-3b71-4023-8920-27d9a247bb20&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F571285c6388145f3b2a07b7e31832477?alt=media&token=d119c86b-b772-4ed4-96aa-3f1a9efecfeb&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
                             }}
                             className="block w-full text-left px-4 py-3 text-sm text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors"
                           >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -433,7 +433,7 @@ const Navigation = () => {
                             onClick={() => {
                               setIsOpen(false);
                               setIsMenuDropdownOpen(false);
-                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F62e80d2c7f5843b9a20f8432a4164c35?alt=media&token=8d83d462-3b71-4023-8920-27d9a247bb20&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F571285c6388145f3b2a07b7e31832477?alt=media&token=d119c86b-b772-4ed4-96aa-3f1a9efecfeb&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
                             }}
                             className="block w-full text-left px-4 py-2 text-sm text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
                           >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -230,6 +230,15 @@ const Navigation = () => {
                           >
                             Kosher
                           </button>
+                          <button
+                            onClick={() => {
+                              setIsMenuDropdownOpen(false);
+                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F62e80d2c7f5843b9a20f8432a4164c35?alt=media&token=8d83d462-3b71-4023-8920-27d9a247bb20&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                            }}
+                            className="block w-full text-left px-4 py-3 text-sm text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors"
+                          >
+                            Takeout Menu (PDF)
+                          </button>
                         </div>
                       </>
                     )}
@@ -419,6 +428,16 @@ const Navigation = () => {
                             className="block w-full text-left px-4 py-2 text-sm text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
                           >
                             Kosher
+                          </button>
+                          <button
+                            onClick={() => {
+                              setIsOpen(false);
+                              setIsMenuDropdownOpen(false);
+                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F62e80d2c7f5843b9a20f8432a4164c35?alt=media&token=8d83d462-3b71-4023-8920-27d9a247bb20&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                            }}
+                            className="block w-full text-left px-4 py-2 text-sm text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                          >
+                            Takeout Menu (PDF)
                           </button>
                         </div>
                       )}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -233,7 +233,7 @@ const Navigation = () => {
                           <button
                             onClick={() => {
                               setIsMenuDropdownOpen(false);
-                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F571285c6388145f3b2a07b7e31832477?alt=media&token=d119c86b-b772-4ed4-96aa-3f1a9efecfeb&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F9f1912d9192648c2a8c51dbe5a32c1b4?alt=media&token=08d85958-fe7c-4dec-bd8f-755bdf616fd7&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
                             }}
                             className="block w-full text-left px-4 py-3 text-sm text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors"
                           >
@@ -433,7 +433,7 @@ const Navigation = () => {
                             onClick={() => {
                               setIsOpen(false);
                               setIsMenuDropdownOpen(false);
-                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F571285c6388145f3b2a07b7e31832477?alt=media&token=d119c86b-b772-4ed4-96aa-3f1a9efecfeb&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
+                              window.open("https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F9f1912d9192648c2a8c51dbe5a32c1b4?alt=media&token=08d85958-fe7c-4dec-bd8f-755bdf616fd7&apiKey=ad5fa173f30f42cb936245efbd928c96", "_blank");
                             }}
                             className="block w-full text-left px-4 py-2 text-sm text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
                           >

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -62,12 +62,12 @@ const HeroSection = () => {
             </Button>
 
             <Button
-              asChild
               variant="outline"
               size="lg"
+              onClick={handleViewMenu}
               className="px-8 py-4 text-lg font-medium bg-white/95 backdrop-blur-sm hover:bg-white border-white/50 hover:border-white text-gray-900 hover:text-gray-900 shadow-soft"
             >
-              <Link to="/menu">View Menu</Link>
+              View Menu
             </Button>
 
             <Button

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { ArrowRight, Play, Star, Users, Award } from "lucide-react";
 
 const HeroSection = () => {

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -3,6 +3,13 @@ import { Link, useNavigate } from "react-router-dom";
 import { ArrowRight, Play, Star, Users, Award } from "lucide-react";
 
 const HeroSection = () => {
+  const navigate = useNavigate();
+
+  const handleViewMenu = () => {
+    navigate("/menu");
+    window.scrollTo(0, 0);
+  };
+
   return (
     <section className="relative min-h-screen flex items-center overflow-hidden">
       {/* Background Image */}

--- a/src/components/sections/MenuSection.tsx
+++ b/src/components/sections/MenuSection.tsx
@@ -1,11 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Link } from "react-router-dom";
-import {
-  ArrowRight,
-  Star,
-  Flame,
-} from "lucide-react";
+import { ArrowRight, Star, Flame } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const MenuSection = () => {
@@ -13,56 +9,65 @@ const MenuSection = () => {
     {
       name: "Chicken Thigh Steak (K)",
       description: "Two sides of your choice.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fd4d89d7a8cfc4ea6b641fea272a70744?format=webp&width=800",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fd4d89d7a8cfc4ea6b641fea272a70744?format=webp&width=800",
       badges: ["Kosher"],
       spicy: false,
     },
     {
       name: "Kosher Rib Eye Steak (K)",
       description: "16oz Angus all-natural steak, two sides of your choice.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F0d0477c50fcb40dca29f991ff8979804?format=webp&width=800",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F0d0477c50fcb40dca29f991ff8979804?format=webp&width=800",
       badges: ["Kosher"],
       spicy: false,
     },
     {
       name: "Kababonim (K)",
       description: "Two sides of your choice.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F64767615d955453e96cc6f9fed97d768?format=webp&width=800",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F64767615d955453e96cc6f9fed97d768?format=webp&width=800",
       badges: ["Kosher"],
       spicy: false,
     },
     {
       name: "Chicken Tenders Skewer (K)",
       description: "Two sides of your choice.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fff1e37af1812431594a84a621416dca2?format=webp&width=800",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fff1e37af1812431594a84a621416dca2?format=webp&width=800",
       badges: ["Kosher"],
       spicy: false,
     },
     {
       name: "Spicy Merguez Sausages (K)",
       description: "Two sides of your choice.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fd6a63fa04cc848b998210dbece197533?format=webp&width=800",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fd6a63fa04cc848b998210dbece197533?format=webp&width=800",
       badges: ["Kosher"],
       spicy: true,
     },
     {
       name: "Beef Angus Sliders (K)",
-      description: "Ketchup, mayo, lettuce, tomato, roasted onion, served with French fries.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fe1d3cec5ef8a48609bed01cd65f2f56f?format=webp&width=800",
+      description:
+        "Ketchup, mayo, lettuce, tomato, roasted onion, served with French fries.",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2Fe1d3cec5ef8a48609bed01cd65f2f56f?format=webp&width=800",
       badges: ["Kosher"],
       spicy: false,
     },
     {
       name: "Pita Arayes (K)",
       description: "Ground beef & lamb, tahini, harissa, pickled lemon spread.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F6fcd9851f5f5484db13733a53c1f70fa?format=webp&width=800",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F6fcd9851f5f5484db13733a53c1f70fa?format=webp&width=800",
       badges: ["Kosher"],
       spicy: false,
     },
     {
       name: "Shnitzelonim (K)",
       description: "Two sides of your choice.",
-      image: "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F6ea349aae6014677a5727d2d276a91bb?format=webp&width=800",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2Ff273f29613d947e0adfbbfd1507382bb%2F6ea349aae6014677a5727d2d276a91bb?format=webp&width=800",
       badges: ["Kosher"],
       spicy: false,
     },
@@ -80,7 +85,9 @@ const MenuSection = () => {
             <span className="block text-red-700">Kosher</span>
           </h2>
           <p className="text-lg text-foreground/80 leading-relaxed text-balance">
-            Kosher-style meat is served in this section only. All other meat on our menu is not kosher. Please note that none of our food is prepared in a fully kosher kitchen.
+            Kosher-style meat is served in this section only. All other meat on
+            our menu is not kosher. Please note that none of our food is
+            prepared in a fully kosher kitchen.
           </p>
         </div>
 

--- a/src/components/sections/MenuSection.tsx
+++ b/src/components/sections/MenuSection.tsx
@@ -152,7 +152,7 @@ const MenuSection = () => {
             className="bg-red-600 hover:bg-red-700 text-white px-8 group"
           >
             <a
-              href="https://www.toasttab.com/local/order/hummusbargrill/r-7fc07f7e-2b14-4999-8bd9-8c05a07d8e59"
+              href="https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F62e80d2c7f5843b9a20f8432a4164c35?alt=media&token=8d83d462-3b71-4023-8920-27d9a247bb20&apiKey=ad5fa173f30f42cb936245efbd928c96"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/sections/MenuSection.tsx
+++ b/src/components/sections/MenuSection.tsx
@@ -152,7 +152,7 @@ const MenuSection = () => {
             className="bg-red-600 hover:bg-red-700 text-white px-8 group"
           >
             <a
-              href="https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F62e80d2c7f5843b9a20f8432a4164c35?alt=media&token=8d83d462-3b71-4023-8920-27d9a247bb20&apiKey=ad5fa173f30f42cb936245efbd928c96"
+              href="https://cdn.builder.io/o/assets%2Fad5fa173f30f42cb936245efbd928c96%2F571285c6388145f3b2a07b7e31832477?alt=media&token=d119c86b-b772-4ed4-96aa-3f1a9efecfeb&apiKey=ad5fa173f30f42cb936245efbd928c96"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Purpose

The user requested several menu-related improvements to enhance navigation and provide updated PDF menu links. The main goals were to:
- Add a takeout menu button to the navigation dropdown
- Update menu PDF links to point to new hosted versions
- Improve the "View Menu" button behavior to scroll to top of menu page
- Replace social media links and update favicon assets

## Code changes

### Navigation Updates
- Added "Takeout Menu (PDF)" button to both desktop and mobile menu dropdowns
- Updated "View Menu" button in hero section to navigate and scroll to top of menu page
- Replaced Twitter link with TikTok in footer social links

### Menu PDF Links
- Updated kosher section "View Full Menu & Order" button to link to new PDF: `571285c6388145f3b2a07b7e31832477`
- Added takeout menu PDF button linking to: `9f1912d9192648c2a8c51dbe5a32c1b4`

### Asset Updates
- Replaced local favicon files with Builder.io hosted WebP format icons
- Updated favicon sizes (16x16, 32x32, 180x180) and mask icon to use CDN URLs
- Removed "Locations" link from footer quick links
- Updated social media icon import (Twitter → Music for TikTok)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f14e6404478b4313848f156f2f59b0b9/nova-nest)

👀 [Preview Link](https://f14e6404478b4313848f156f2f59b0b9-nova-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f14e6404478b4313848f156f2f59b0b9</projectId>-->
<!--<branchName>nova-nest</branchName>-->