### PR TITLE
Fix dropdown navigation by adding section IDs to menu

### DIFF
--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -275,14 +275,16 @@ const Menu = () => {
     buttonText,
     pdfLink,
     showButton = false,
+    id,
   }: {
     title: string;
     items: Array<{ name: string; description: string; image: string }>;
     buttonText?: string;
     pdfLink?: string;
     showButton?: boolean;
+    id?: string;
   }) => (
-    <section className="mb-6 md:mb-8">
+    <section id={id} className="mb-6 md:mb-8">
       <h2 className="menu-section-title text-2xl font-bold text-black mt-6 mb-3 pb-2 border-b border-gray-200 text-left">
         {title}
       </h2>

--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -358,14 +358,20 @@ const Menu = () => {
         <section className="py-12 md:py-20 bg-gray-50">
           <div className="container-custom section-padding max-w-6xl">
             <MenuSection
+              id="breakfast-section"
               title="BREAKFAST MENU"
               items={menuData.breakfast}
               buttonText="View Full Breakfast Menu"
               pdfLink="/pdfs/hummus-bar-breakfast-menu.pdf"
               showButton={true}
             />
-            <MenuSection title="APPETIZERS" items={menuData.appetizers} />
             <MenuSection
+              id="appetizers-section"
+              title="APPETIZERS"
+              items={menuData.appetizers}
+            />
+            <MenuSection
+              id="lunch-dinner-section"
               title="LUNCH & DINNER MENU"
               items={menuData.lunchDinner}
               buttonText="View Full Lunch & Dinner Menu"
@@ -373,14 +379,23 @@ const Menu = () => {
               showButton={true}
             />
             <MenuSection
+              id="drinks-section"
               title="DRINKS"
               items={menuData.drinks}
               buttonText="View Full Drinks Menu"
               pdfLink="/pdfs/hummus-bar-drinks.pdf"
               showButton={true}
             />
-            <MenuSection title="DESSERTS" items={menuData.desserts} />
-            <MenuSection title="KIDS MENU" items={menuData.kidsMenu} />
+            <MenuSection
+              id="desserts-section"
+              title="DESSERTS"
+              items={menuData.desserts}
+            />
+            <MenuSection
+              id="kids-menu-section"
+              title="KIDS MENU"
+              items={menuData.kidsMenu}
+            />
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Purpose
The user reported that clicking dropdown buttons in the menu navigation wasn't taking them to the corresponding menu sections. This fix enables proper anchor link navigation by adding unique IDs to each menu section.

## Code changes
- Added optional `id` parameter to the `MenuSection` component interface
- Applied the `id` prop to the section element to enable anchor linking
- Added unique section IDs to all menu sections:
  - `breakfast-section`
  - `appetizers-section` 
  - `lunch-dinner-section`
  - `drinks-section`
  - `desserts-section`
  - `kids-menu-section`

This allows dropdown navigation links to properly scroll to their target sections when clicked.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/975047e4cf56432687d645892df5a4c6/flare-nest)

👀 [Preview Link](https://975047e4cf56432687d645892df5a4c6-flare-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>975047e4cf56432687d645892df5a4c6</projectId>-->
<!--<branchName>flare-nest</branchName>-->