### PR TITLE
Fix redirects for Render deployment

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,0 @@
-/dine-in /menu 301
-/takeout-catering /catering 301
-/social /contact 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,7 @@
+# Custom redirects
+/dine-in /menu 301
+/takeout-catering /catering 301
+/social /contact 301
+
+# SPA fallback - this must be last
 /*    /index.html   200

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  - type: web
+    name: fusion-starter
+    env: static
+    buildCommand: npm run build
+    staticPublishPath: ./dist
+    routes:
+      - type: redirect
+        source: /dine-in
+        destination: /menu
+        status: 301
+      - type: redirect
+        source: /takeout-catering
+        destination: /catering
+        status: 301
+      - type: redirect
+        source: /social
+        destination: /contact
+        status: 301
+      - type: rewrite
+        source: /*
+        destination: /index.html


### PR DESCRIPTION
## Purpose
Fix redirect configuration to work properly with Render deployment. The user reported that slug URLs were returning "not found" errors when searched on the internet, indicating the redirects weren't functioning correctly for the hosting platform.

## Code changes
- **Moved redirects file**: Relocated `_redirects` from root to `public/_redirects` directory for proper static site handling
- **Added Render configuration**: Created `render.yaml` with explicit redirect routes and SPA fallback configuration
- **Enhanced redirects format**: Added comments and organized redirect rules in `public/_redirects` with SPA fallback as the last rule
- **Configured redirect routes**: Set up 301 redirects for `/dine-in` → `/menu`, `/takeout-catering` → `/catering`, and `/social` → `/contact` in both files

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/975047e4cf56432687d645892df5a4c6/zen-lab)

👀 [Preview Link](https://975047e4cf56432687d645892df5a4c6-zen-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>975047e4cf56432687d645892df5a4c6</projectId>-->
<!--<branchName>zen-lab</branchName>-->