### PR TITLE
Remove redirects configuration file

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,0 @@
-/dine-in /menu 301
-/takeout-catering /catering 301
-/social /contact 301
-/* /index.html 200


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user was investigating their build output and deployment structure, checking for specific files like `about.html` and `index.html`. They ultimately decided to clean up their project by removing the redirects configuration.

## Code changes

- Deleted `public/_redirects` file that contained URL redirect rules
- Removed 4 redirect configurations:
  - `/dine-in` → `/menu` (301 redirect)
  - `/takeout-catering` → `/catering` (301 redirect) 
  - `/social` → `/contact` (301 redirect)
  - Catch-all fallback to `/index.html` (200 response)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/975047e4cf56432687d645892df5a4c6/quantum-landing)

👀 [Preview Link](https://975047e4cf56432687d645892df5a4c6-quantum-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>975047e4cf56432687d645892df5a4c6</projectId>-->
<!--<branchName>quantum-landing</branchName>-->