### PR TITLE
Add URL redirects for legacy restaurant pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,12 @@
+/takeout-catering /catering 301
+/dine-in /menu 301
+/delivery-menu /menu 301
+/gallery /about 301
+/membership /about 301
+/shop /about 301
+/checkout /about 301
+/social-post-details /about 301
+/press /about 301
+/jobs /about 301
+
 /* /index.html 200

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,55 @@
 {
+  "redirects": [
+    {
+      "source": "/takeout-catering",
+      "destination": "/catering",
+      "permanent": true
+    },
+    {
+      "source": "/dine-in",
+      "destination": "/menu",
+      "permanent": true
+    },
+    {
+      "source": "/delivery-menu",
+      "destination": "/menu",
+      "permanent": true
+    },
+    {
+      "source": "/gallery",
+      "destination": "/about",
+      "permanent": true
+    },
+    {
+      "source": "/membership",
+      "destination": "/about",
+      "permanent": true
+    },
+    {
+      "source": "/shop",
+      "destination": "/about",
+      "permanent": true
+    },
+    {
+      "source": "/checkout",
+      "destination": "/about",
+      "permanent": true
+    },
+    {
+      "source": "/social-post-details",
+      "destination": "/about",
+      "permanent": true
+    },
+    {
+      "source": "/press",
+      "destination": "/about",
+      "permanent": true
+    },
+    {
+      "source": "/jobs",
+      "destination": "/about",
+      "permanent": true
+    }
+  ],
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Purpose

The user needed to implement URL redirects for a restaurant website to handle legacy page URLs and redirect them to appropriate current pages. This ensures visitors using old bookmarks or links are properly redirected to the correct content sections.

## Code changes

- **Added redirects configuration to `vercel.json`**: Implemented 10 permanent redirects (301) mapping legacy URLs to current pages
- **Added redirects to `public/_redirects`**: Created corresponding redirect rules in Netlify format for deployment compatibility
- **Redirect mapping**:
  - `/takeout-catering` → `/catering`
  - `/dine-in`, `/delivery-menu` → `/menu`
  - `/gallery`, `/membership`, `/shop`, `/checkout`, `/social-post-details`, `/press`, `/jobs` → `/about`

All redirects are configured as permanent (301) to preserve SEO value and ensure proper browser caching.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/975047e4cf56432687d645892df5a4c6/flare-den)

👀 [Preview Link](https://975047e4cf56432687d645892df5a4c6-flare-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>975047e4cf56432687d645892df5a4c6</projectId>-->
<!--<branchName>flare-den</branchName>-->